### PR TITLE
allow empty rows in _sqa_to_frame

### DIFF
--- a/vbench/db.py
+++ b/vbench/db.py
@@ -144,6 +144,8 @@ class BenchmarkDB(object):
 
 def _sqa_to_frame(result):
     rows = [tuple(x) for x in result]
+    if not rows:
+        return DataFrame(columns=result.keys())
     return DataFrame.from_records(rows, columns=result.keys())
 
 


### PR DESCRIPTION
on first use the list will be empty, and `DataFrame.from_records()` doesn't seem to like empty lists (pandas bug?):

``` python
In [2]: DataFrame.from_records([], columns=['a','b'])
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
/Users/minrk/dev/ip/mine/<ipython-input-2-6db21c2c0856> in <module>()
----> 1 pd.DataFrame.from_records([], columns=['a','b'])

/Users/minrk/dev/py/pandas/pandas/core/frame.pyc in from_records(cls, data, index, exclude, columns, names)
    533             columns, sdict = _rec_to_dict(data)
    534         else:
--> 535             sdict, columns = _list_to_sdict(data, columns)
    536 
    537         if exclude is None:

/Users/minrk/dev/py/pandas/pandas/core/frame.pyc in _list_to_sdict(data, columns)
   3560 
   3561 def _list_to_sdict(data, columns):
-> 3562     if isinstance(data[0], tuple):
   3563         content = list(lib.to_object_array_tuples(data).T)
   3564     else:

IndexError: list index out of range
```
